### PR TITLE
change date data type to string, no longer get warning for doesnt match

### DIFF
--- a/models/Truck.js
+++ b/models/Truck.js
@@ -11,8 +11,8 @@ const truckSchema = new mongoose.Schema({
 	vin: String,
 	plate: String,
 	status: String,
-	lastServiced: Date,
-	serviceDue: Date,
+	lastServiced: String,
+	serviceDue: String,
 	lastUsers: {
 		ref: 'users',
 		type: mongoose.ObjectId,


### PR DESCRIPTION
were not accessing the date in anyway but to display and change on the modal at the moment. this stoped it from throwing console warnings every time you update a date after you do it the first time to update the data set, future additions shouldn't warn